### PR TITLE
Fix returning view on scroll.

### DIFF
--- a/frontend/src/HangHub.js
+++ b/frontend/src/HangHub.js
@@ -153,6 +153,9 @@ export default class HangHub {
 			hangHubElement.className = 'discussion-sidebar-item';
 			hangHubElement.id = 'hanghub';
 
+			// GitHub sets top margin on discussion-sidebar-item only on PR pages. It needs to be set also on issues.
+			hangHubElement.style.marginTop = '15px';
+
 			sidebarElement.appendChild( hangHubElement );
 		}
 


### PR DESCRIPTION
It's such an interesting case. GitHub sets `margin-top` on this element only on pull request pages. On issue pages, this margin wasn't set so `_updatePosition()` couldn't set position properly (missing `15px`).
Closes #18.