### PR TITLE
Fix HangHub performance

### DIFF
--- a/frontend/manifest.json
+++ b/frontend/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "HangHub",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "HangHub allows you to see who is viewing or commenting on the same GitHub issue or pull request as you in real time.",
   "permissions": [
     "activeTab",

--- a/frontend/src/HangHub.js
+++ b/frontend/src/HangHub.js
@@ -44,7 +44,7 @@ export default class HangHub {
 
 		this._observer = new window.MutationObserver( debounce( () => {
 			this._interactWithSocket();
-		}, 70 ) );
+		}, 750 ) );
 
 		this._observer.observe( document.querySelector( 'body' ), {
 			childList: true,

--- a/frontend/src/HangHub.js
+++ b/frontend/src/HangHub.js
@@ -133,7 +133,7 @@ export default class HangHub {
 				this._renderCollaboratorCounter( users );
 				this._updatePosition();
 
-				this._connectedUsers = [ ...users ];
+				this._connectedUsers = users;
 			}
 		} );
 	}


### PR DESCRIPTION
Closes #30
Closes #29 
Closes #28 

A few performance aspects have been improved:
1. Debounce has been significantly increased. Higher delay in this tool does not have a big impact on UX so it can be increased.
2. Fix regular expression. The regular expression was not able to parse PR tabs like `files` or `checks` properly. It caused continuous tries to append the HangHub elements to the GH view.
3. Fix collaborators counter - due to the new GH design, the counter wasn't displayed properly.
4. Improve preventing redundant repaints. The previous approach didn't work properly. The current approach rerenders content only in the main issue/pr page, only if the elements are not rendered or if any user changed its state.
5. The 'commenting' state works properly for reviews now.