### PR TITLE
chore: Update used Node.js version and add missing `.gitignore` file.

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+package-lock.json
+.env
+.DS_Store

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2003-2023, CKSource Holding sp. z o.o.. All rights reserved.
 # This file is licensed under the terms of the MIT License (see LICENSE.md).
 
-FROM node:10
+FROM node:18
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
The backend is now run on Node 18 so to represent the actual state, the Dockerfile has been updated. Added a missing `.gitignore` file to be able to work with multiple Git remotes in the backend directory.