### PR TITLE
fix: Handle case when removed issue key does not exist

### DIFF
--- a/backend/src/InMemoryDriver.js
+++ b/backend/src/InMemoryDriver.js
@@ -21,6 +21,10 @@ module.exports = class InMemoryDriver {
 	}
 
 	delete( issueKey, socketId ) {
+		if ( !this._db[ issueKey ] ) {
+			return;
+		}
+
 		delete this._db[ issueKey ][ socketId ];
 	}
 };

--- a/backend/src/RedisDriver.js
+++ b/backend/src/RedisDriver.js
@@ -35,6 +35,12 @@ module.exports = class RedisDriver {
 	}
 
 	async delete( issueKey, socketId ) {
+		const exists = await this._client.exists( issueKey );
+
+		if ( !exists ) {
+			return;
+		}
+
 		await this._client.hdel( issueKey, socketId );
 	}
 };

--- a/backend/tests/SessionInMemoryRepository.js
+++ b/backend/tests/SessionInMemoryRepository.js
@@ -100,6 +100,12 @@ describe( 'SessionInMemoryRepository', () => {
 
 			expect( await repository.getAll( issueKey ) ).to.deep.equal( [] );
 		} );
+
+		it( 'should not crash if there is not matching key', async () => {
+			await repository.delete( 'invalidKey', 'IbVmSiD_LoULFK2yAAAB' );
+
+			expect( await repository.getAll( 'invalidKey' ) ).to.deep.equal( [] );
+		} );
 	} );
 } );
 

--- a/backend/tests/SessionRedisRepository.js
+++ b/backend/tests/SessionRedisRepository.js
@@ -122,6 +122,12 @@ describe( 'SessionRedisRepository', () => {
 
 			expect( Object.keys( await redisClient.hgetall( issueKey ) ).length ).to.equal( 0 );
 		} );
+
+		it( 'should not crash if there is not matching key', async () => {
+			await repository.delete( 'invalidKey', 'IbVmSiD_LoULFK2yAAAB' );
+
+			expect( Object.keys( await redisClient.hgetall( 'invalidKey' ) ).length ).to.equal( 0 );
+		} );
 	} );
 } );
 


### PR DESCRIPTION
As both drivers when it's restarted remove their content, it might be a case when a client tries to trigger the delete operation after the backend restart. In such a case it led to a situation when the backend application crashed as the drivers were not able to handle the described situation correctly.